### PR TITLE
Worker container's boot problem solved. Only one container is being c…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,8 +51,7 @@ services:
       - web
     restart: on-failure
   worker:
-    build: 
-      context: ./
+    image: mobileaudit_web
     env_file:
       - ./.env.example
     entrypoint: [ '/worker_entrypoint.sh' ]

--- a/entrypoint/worker_entrypoint.sh
+++ b/entrypoint/worker_entrypoint.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+mkdir -p /app/app/logs
 celery --app app.worker.celery worker --concurrency 4 --loglevel INFO


### PR DESCRIPTION
When the project was built with `docker-compose up` command, worker container was giving error because there was no directory located `/app/app/logs`. This problem solved via adding `mkdir -p /app/app/logs` line to the `worker_entrypoint.sh` file.  
  
And also both `web` and `worker` container was using the same `Dockerfile` but creating two different containers. Now the container is being built only for `web` container and `worker` container is using the same image.