### PR TITLE
Docker-composer parsing fix for allowed hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 SECRET_KEY='akj)aa@2rp+$duf_m$)4!@cc#()h@q(ag0f=h8#1@dlpdouni5'
 DEBUG=0
-DJANGO_ALLOWED_HOSTS=web app localhost 127.0.0.1 [::1]
+DJANGO_ALLOWED_HOSTS=['web','app','localhost','127.0.0.1']
 ENV=PROD
 SQL_ENGINE=django.db.backends.postgresql
 SQL_DATABASE=postgres

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -64,7 +64,7 @@ SECRET_KEY = env("SECRET_KEY", "<SECRET_KEY>")
 
 DEBUG = int(env("DEBUG", 0))
 
-ALLOWED_HOSTS = env("DJANGO_ALLOWED_HOSTS", "localhost").split(" ")
+ALLOWED_HOSTS = tuple(env("DJANGO_ALLOWED_HOSTS", ['web','app','localhost','127.0.0.1']))
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases


### PR DESCRIPTION
Environment allowed host changes to make it work with Docker Compose V2
Close #48 