### PR TITLE
chore: upgrade all docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9.7-buster@sha256:79a631c93960c5919f27f3403e734ec19b130008370a5f902141bcff2e6d6f4c
+FROM python:3.9.16-buster@sha256:5e28891402c02291f65c6652a8abddedcb5af15933e923c07c2670f836243833
+
 # Update and package installation
 RUN apt-get update && \
 	apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 
 **MobileAudit** - SAST and Malware Analysis for Android Mobile APKs
 
+- [Mobile Audit](#mobile-audit)
   - [Components](#components)
   - [Docker Base images](#docker-base-images)
   - [Main features](#main-features)
   - [Patterns](#patterns)
-  - [Integrations](#integrations)
-  - [Install](#install)
+  - [Models](#models)
+    - [Virus Total (API v3)](#virus-total-api-v3)
+    - [Defect Dojo (API v2)](#defect-dojo-api-v2)
+    - [MalwareDB \& Maltrail](#malwaredb--maltrail)
+  - [Installation](#installation)
   - [API v1](#api-v1)
     - [Usage](#usage)
     - [Swagger](#swagger)
@@ -49,22 +53,22 @@ For easy access there is a sidebar on the left page of the scan:
 
 ![Schema](app/static/architecture.png)
 
-- **db**: PostgreSQL 13.2
-- **nginx**: Nginx 1.19.10
-- **rabbitmq**: RabbitMQ 3.8.14
-- **worker**: Celery 5.0.5
-- **web**: Mobile Audit App
+- **db**: PostgreSQL 3.11.5
+- **nginx**: Nginx 1.23.3
+- **rabbitmq**: RabbitMQ 3.11.5
+- **worker**: Celery 5.2.2
+- **web**: Mobile Audit App (Django 3.2.16)
 
 ### Docker Base images
 
 Image is based on python buster. Link to [Docker Hub image](https://hub.docker.com/repository/docker/mpast/mobile_audit)
 
 | Image |  Tags | Base |
-|--------------------|-------|---------------------|
-| mpast/mobile_audit | 1.3.8 | python:3.9.4-buster |
-| mpast/mobile_audit | 1.3.6 | python:3.9.2-buster |
-| mpast/mobile_audit | 1.3.0 | python:3.9.1-buster |
-| mpast/mobile_audit | 1.0.0 | python:3.9.0-buster |
+|--------------------|-------|--------------------- |
+| mpast/mobile_audit | 3.0.0 | python:3.9.16-buster |
+| mpast/mobile_audit | 2.2.1 | python:3.9.7-buster  |
+| mpast/mobile_audit | 1.3.8 | python:3.9.4-buster  |
+| mpast/mobile_audit | 1.0.0 | python:3.9.0-buster  |
 
 ### Main features
 
@@ -216,7 +220,7 @@ By default, there is a volume in `docker-compose.yml` with the configuration wit
 - ./nginx/app.conf:/etc/nginx/conf.d/app.conf
 ```
 
-** In production environment** use `docker-compose.prod.yaml` with port 443
+**In a production environment** use `docker-compose.prod.yaml` with port 443
 ```yml
 - ./nginx/app_tls.conf:/etc/nginx/conf.d/app_tls.conf
 ```
@@ -225,7 +229,7 @@ By default, there is a volume in `docker-compose.yml` with the configuration wit
 
 All the environment variables are in a `.env` file, there is an `.env.example` with all the variables needed. Also there are collected in `app/config/settings.py`:
 
-```py
+```python
 CWE_URL = env('CWE_URL', 'https://cwe.mitre.org/data/definitions/')
 
 MALWARE_ENABLED = env('MALWARE_ENABLED', True)

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   db:
-    image: postgres:13.4@sha256:97e5e91582e89514277912d4b7c95bceabdede3482e32395bcb40099abd9c506
+    image: postgres:15.1-alpine@sha256:07c3361c9e8e1d734dfc51e239327b11d25196347be630fbdc556ca41f219184
     env_file:
       - ./.env.example
     environment:
@@ -28,7 +28,7 @@ services:
       - db
     restart: on-failure
   nginx:
-    image: nginx:1.21.3@sha256:853b221d3341add7aaadf5f81dd088ea943ab9c918766e295321294b035f3f3e
+    image: nginx:1.23.3-alpine@sha256:dd8a054d7ef030e94a6449783605d6c306c1f69c10c2fa06b66a030e0d1db793
     ports:
       - "443:443"
     volumes:
@@ -40,7 +40,7 @@ services:
       - web
     restart: on-failure
   rabbitmq:
-    image: rabbitmq:3.8.14-management@sha256:c7e1e3c34f1a6a5c089723763f04dc4c483d12f2fabb2fe48faee6f3d3998c69
+    image: rabbitmq:3.11.5-management-alpine@sha256:826a39d68330e7c380f527d0ac31e87999ade0afa6747e688c9d56989319a2c2
     env_file:
       - ./.env.example
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   db:
-    image: postgres:13.4@sha256:97e5e91582e89514277912d4b7c95bceabdede3482e32395bcb40099abd9c506
+    image: postgres:15.1-alpine@sha256:07c3361c9e8e1d734dfc51e239327b11d25196347be630fbdc556ca41f219184
     env_file:
       - ./.env.example
     environment:
@@ -28,7 +28,7 @@ services:
       - db
     restart: on-failure
   nginx:
-    image: nginx:1.21.3@sha256:853b221d3341add7aaadf5f81dd088ea943ab9c918766e295321294b035f3f3e
+    image: nginx:1.23.3-alpine@sha256:dd8a054d7ef030e94a6449783605d6c306c1f69c10c2fa06b66a030e0d1db793
     ports:
       - "8888:8888"
     volumes:
@@ -39,7 +39,7 @@ services:
       - web
     restart: on-failure
   rabbitmq:
-    image: rabbitmq:3.8.14-management@sha256:c7e1e3c34f1a6a5c089723763f04dc4c483d12f2fabb2fe48faee6f3d3998c69
+    image: rabbitmq:3.11.5-management-alpine@sha256:826a39d68330e7c380f527d0ac31e87999ade0afa6747e688c9d56989319a2c2
     env_file:
       - ./.env.example
     environment:


### PR DESCRIPTION
* Upgrade python to 3.9.16
* Upgrade nginx to 1.23.3
* Upgrade rabbitmq to 3.11.5
* Upgrade postgres to 15.1
**Note**: Previous postgres data is not compatible with the new version, so to be able to run the new version, the docker volumes must be removed and recreated:
`docker compose down`
`docker volume list`
`docker volume rm <volumename>`
`docker compose up`
In case you care about the data, use `pg_dumpall` to dump you data before removing the files and restore after you run `docker-compose up`

