### PR TITLE
chore: add rabbitmq logs directory to avoid permission issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .env
 .vscode
 app/logs/*
-rabbitmq/logs/*
+rabbitmq/logs/*.log
 nginx/logs/*
 app/media/*
 *.sqlite3


### PR DESCRIPTION
Issue related to #104 for kali linux hosts